### PR TITLE
module 2, make redeployment of inventory-database work, and generic

### DIFF
--- a/content/modules/ROOT/pages/module-02.adoc
+++ b/content/modules/ROOT/pages/module-02.adoc
@@ -635,6 +635,15 @@ The inventory information is now available.
 oc get pods
 ----
 
+.Sample Output
+[source,bash]
+----
+NAME                                          READY   STATUS    RESTARTS   AGE
+inventory-database-574fc65f75-dlckp           1/1     Running   0          5m54s
+skupper-router-757c7c4984-bww2l               2/2     Running   0          5m46s
+skupper-service-controller-6fb44dfdd5-pn94b   1/1     Running   0          5m44s
+----
+
 * Use the inventory-database pod's name for the
 following commands. For example:
 
@@ -642,15 +651,14 @@ following commands. For example:
 [.console-input]
 [source,bash,subs="+attributes,macros+"]
 ----
-oc logs inventory-f6957f6d5-7tggx
+oc logs deployment/inventory-database
 ----
 
 [.console-input]
 [source,bash,subs="+attributes,macros+"]
 ----
-oc delete pod inventory-f6957f6d5-7tggx
+oc rollout restart deployment/inventory-database
 ----
-
 
 * Explore the different components in Red Hat Service Interconnect:
 


### PR DESCRIPTION
Name of inventory-database deployment was wrong.

Also, no need to fuss with pod names.  Use oc rollout restart deployment/inventory-database